### PR TITLE
fix: remove duplicate env variables used for NHS login

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -34,5 +34,3 @@ ParticipantManagerDatabaseConnectionString=Server=${DATABASE_HOST};Database=${DA
 # KeyVault
 KEY_VAULT_URL=https://kv-parman-test-uks.vault.azure.net/
 SECRET_NAME=nhs-login-sandpit-secret
-OAUTH_ISSUER=https://auth.sandpit.signin.nhs.uk
-OAUTH_AUDIENCE=screening participant manager

--- a/src/api/ParticipantManager.Experience.API/Program.cs
+++ b/src/api/ParticipantManager.Experience.API/Program.cs
@@ -19,7 +19,7 @@ var host = new HostBuilder()
     services.AddSingleton<IJwksProvider>(provider =>
     {
       var logger = provider.GetRequiredService<ILogger<JwksProvider>>();
-      string issuer = Environment.GetEnvironmentVariable("OAUTH_ISSUER");
+      string issuer = Environment.GetEnvironmentVariable("AUTH_NHSLOGIN_ISSUER_URL");
       return new JwksProvider(logger, issuer);
     });
 

--- a/src/api/ParticipantManager.Experience.API/Services/TokenService.cs
+++ b/src/api/ParticipantManager.Experience.API/Services/TokenService.cs
@@ -17,8 +17,8 @@ namespace ParticipantManager.Experience.API.Services
     {
         private const string AuthHeaderName = "Authorization";
         private const string BearerPrefix = "Bearer ";
-        private readonly string _audience = Environment.GetEnvironmentVariable("OAUTH_AUDIENCE") ?? throw new InvalidOperationException("OAUTH_AUDIENCE environment variable is missing.");
-        private readonly string _issuer = Environment.GetEnvironmentVariable("OAUTH_ISSUER") ?? throw new InvalidOperationException("OAUTH_ISSUER environment variable is missing.");
+        private readonly string _audience = Environment.GetEnvironmentVariable("AUTH_NHSLOGIN_CLIENT_ID") ?? throw new InvalidOperationException("AUTH_NHSLOGIN_CLIENT_ID environment variable is missing.");
+        private readonly string _issuer = Environment.GetEnvironmentVariable("AUTH_NHSLOGIN_ISSUER_URL") ?? throw new InvalidOperationException("AUTH_NHSLOGIN_ISSUER_URL environment variable is missing.");
         public async Task<AccessTokenResult> ValidateToken(HttpRequestData request)
         {
             try


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Remove duplicate env variables used for NHS login

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
