### PR TITLE
feat: use X-Correlation-ID in the API calls

### DIFF
--- a/src/web/app/lib/fetchPatientData.ts
+++ b/src/web/app/lib/fetchPatientData.ts
@@ -3,7 +3,7 @@ import { EligibilityResponse, PathwayResponse } from "@/app/types";
 export async function fetchPatientScreeningEligibility(
   accessToken: string
 ): Promise<EligibilityResponse> {
-  const traceId = crypto.randomUUID();
+  const correlationId = crypto.randomUUID();
 
   try {
     const url = `${process.env.EXPERIENCE_API_URL}/api/eligibility`;
@@ -11,7 +11,7 @@ export async function fetchPatientScreeningEligibility(
       method: "GET",
       headers: {
         Authorization: "Bearer " + accessToken,
-        traceId: traceId,
+        "X-Correlation-ID": correlationId,
       },
     });
 
@@ -32,7 +32,7 @@ export async function fetchPathwayAssignment(
   accessToken: string,
   assignmentId: string
 ): Promise<PathwayResponse> {
-  const traceId = crypto.randomUUID();
+  const correlationId = crypto.randomUUID();
 
   try {
     const url = `${process.env.EXPERIENCE_API_URL}/api/pathwayassignments/${assignmentId}`;
@@ -40,7 +40,7 @@ export async function fetchPathwayAssignment(
       method: "GET",
       headers: {
         Authorization: "Bearer " + accessToken,
-        traceId: traceId,
+        "X-Correlation-ID": correlationId,
       },
     });
 


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Use `X-Correlation-ID` header in the API call request

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
