### PR TITLE
chore: moved namespaces to be inline with c# standard

### DIFF
--- a/tests/ParticipantManager.API.Tests/ParticipantFunctionsTests.cs
+++ b/tests/ParticipantManager.API.Tests/ParticipantFunctionsTests.cs
@@ -1,4 +1,3 @@
-namespace ParticipantManager.API.Tests;
 
 using System.ComponentModel.DataAnnotations;
 using System.Text.Json;
@@ -11,6 +10,8 @@ using ParticipantManager.API.Data;
 using ParticipantManager.API.Functions;
 using ParticipantManager.API.Models;
 using ParticipantManager.TestUtils;
+
+namespace ParticipantManager.API.Tests;
 
 public class ParticipantFunctionsTests
 {

--- a/tests/ParticipantManager.Experience.API.Tests/GetParticipantIdFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/GetParticipantIdFunctionTests.cs
@@ -1,5 +1,3 @@
-namespace ParticipantManager.Experience.API.Tests;
-
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +9,8 @@ using ParticipantManager.Experience.API.Services;
 using ParticipantManager.Shared.Client;
 using ParticipantManager.Shared.DTOs;
 using ParticipantManager.TestUtils;
+
+namespace ParticipantManager.Experience.API.Tests;
 
 public class GetParticipantIdFunctionTests
 {

--- a/tests/ParticipantManager.Experience.API.Tests/PathwayEnrolmentFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/PathwayEnrolmentFunctionTests.cs
@@ -1,5 +1,3 @@
-namespace ParticipantManager.Experience.API.Tests;
-
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +9,8 @@ using ParticipantManager.Experience.API.Functions;
 using ParticipantManager.Experience.API.Services;
 using ParticipantManager.Shared.Client;
 using ParticipantManager.Shared.DTOs;
+
+namespace ParticipantManager.Experience.API.Tests;
 
 public class PathwayEnrolmentFunctionTests
 {

--- a/tests/ParticipantManager.Experience.API.Tests/ScreeningEligibilityFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/ScreeningEligibilityFunctionTests.cs
@@ -1,5 +1,3 @@
-namespace ParticipantManager.Experience.API.Tests;
-
 using System.Security.Claims;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
@@ -11,6 +9,8 @@ using ParticipantManager.Experience.API.Functions;
 using ParticipantManager.Experience.API.Services;
 using ParticipantManager.Shared.Client;
 using ParticipantManager.Shared.DTOs;
+
+namespace ParticipantManager.Experience.API.Tests;
 
 public class ScreeningEligibilityFunctionTests
 {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

moved namespaces from file scoped to be inline with c# standard

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
