### PR TITLE
fix: GetPathwayTypeEnrolmentsByParticipantId need not be a POST endpoint

### DIFF
--- a/src/api/ParticipantManager.API/Functions/PathwayTypeEnrolmentFunctions.cs
+++ b/src/api/ParticipantManager.API/Functions/PathwayTypeEnrolmentFunctions.cs
@@ -18,7 +18,7 @@ public class PathwayTypeEnrolmentFunctions(
 {
     [Function("GetPathwayTypeEnrolmentsByParticipantId")]
     public async Task<IActionResult> GetPathwayTypeEnrolmentsByParticipantId(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", "post", Route = "pathwaytypeenrolments")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "pathwaytypeenrolments")]
         HttpRequest req)
     {
         logger.LogInformation($"{nameof(GetPathwayTypeEnrolmentsByParticipantId)} processed a request.");


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The GetPathwayTypeEnrolmentsByParticipantId endpoint in CRUD API need not be exposed via POST method

## Context

Simplifies API, allows for same path to be used for both GET and POST endpoints in a semantically appropriate way.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [x] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
