### PR TITLE
fix: Return 403 when user is authenticated but does not have access

### DIFF
--- a/src/api/ParticipantManager.Experience.API/Functions/PathwayEnrolmentFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/PathwayEnrolmentFunction.cs
@@ -50,7 +50,7 @@ public class PathwayEnrolmentFunction(
             {
                 logger.LogError("Logged in user does not have access to this record: {@ParticipantId}",
                     new { ParticipantId = participantId });
-                return new UnauthorizedResult();
+                return new ForbidResult();
             }
 
             var enabled = await featureFlagClient.IsFeatureEnabledForParticipant("mays_mvp", participantId);

--- a/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
@@ -48,7 +48,7 @@ public class ScreeningEligibilityFunction(
             {
                 logger.LogError("Logged in user does not have access to this record: {@ParticipantId}",
                     new { ParticipantId = participantId });
-                return new UnauthorizedResult();
+                return new ForbidResult();
             }
 
             var enabled = await featureFlagClient.IsFeatureEnabledForParticipant("mays_mvp", participantId);

--- a/tests/ParticipantManager.Experience.API.Tests/PathwayEnrolmentFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/PathwayEnrolmentFunctionTests.cs
@@ -102,7 +102,7 @@ public class PathwayEnrolmentFunctionTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_NhsNumberDoesNotMatch_ReturnsUnauthorized()
+    public async Task GetPathwayEnrolmentById_NhsNumberDoesNotMatch_ReturnsForbidden()
     {
         // Arrange
         var claims = new List<Claim>
@@ -120,10 +120,11 @@ public class PathwayEnrolmentFunctionTests
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as UnauthorizedResult;
+            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId);
 
         // Assert
-        Assert.Equal(StatusCodes.Status401Unauthorized, response?.StatusCode);
+        Assert.NotNull(response);
+        Assert.IsType<ForbidResult>(response);
     }
 
     [Fact]

--- a/tests/ParticipantManager.Experience.API.Tests/ScreeningEligibilityFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/ScreeningEligibilityFunctionTests.cs
@@ -124,7 +124,7 @@ public class ScreeningEligibilityFunctionTests
     }
 
     [Fact]
-    public async Task GetScreeningEligibility_NhsNumberDoesNotMatch_ReturnsUnauthorized()
+    public async Task GetScreeningEligibility_NhsNumberDoesNotMatch_ReturnsForbidden()
     {
         // Arrange
         var claims = new List<Claim>
@@ -141,10 +141,11 @@ public class ScreeningEligibilityFunctionTests
             .ReturnsAsync(AccessTokenResult.Success(principal));
 
         // Act
-        var response = await _function.GetScreeningEligibility(_request, _participantId) as UnauthorizedResult;
+        var response = await _function.GetScreeningEligibility(_request, _participantId);
 
         // Assert
-        Assert.Equal(StatusCodes.Status401Unauthorized, response?.StatusCode);
+        Assert.NotNull(response);
+        Assert.IsType<ForbidResult>(response);
     }
 
     [Fact]


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

In the scenario where a user is authenticated but does not have access to the resource they have requested, we should return 403 forbidden (not 401 unauthorised).

## Context

Adhere to HTTP standards

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
