### PR TITLE
fix: pass a timeout to limit the execution time for NhsNumberRegex

### DIFF
--- a/src/api/ParticipantManager.Shared/NhsNumberHashingPolicy.cs
+++ b/src/api/ParticipantManager.Shared/NhsNumberHashingPolicy.cs
@@ -8,8 +8,10 @@ public class NhsNumberHashingPolicy : IDestructuringPolicy
 {
     private const string NhsNumberPattern = @"\b\d{10}\b";
 
+    private static readonly TimeSpan RegexTimeout = TimeSpan.FromSeconds(5);
+
     private static readonly Regex NhsNumberRegex =
-        new(NhsNumberPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase);
+        new(NhsNumberPattern, RegexOptions.Compiled | RegexOptions.IgnoreCase | RegexOptions.NonBacktracking, RegexTimeout);
 
     private static readonly bool DisableHashing =
         Environment.GetEnvironmentVariable("DISABLE_NHS_HASHING")?.ToLower() == "false";


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

[fix: pass a timeout to limit the execution time for NhsNumberRegex](https://github.com/NHSDigital/dtos-participant-manager/commit/5452ddbbbc12ad35182a2d1464ffdaa7217f7868)

Resolves https://sonarcloud.io/project/security_hotspots?id=NHSDigital_dtos-participant-manager&hotspots=AZXMhrp3f3D3XJBwumxc

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
