### PR TITLE
refactor: Removed unnecessary packages

### DIFF
--- a/src/api/ParticipantManager.API/ParticipantManager.API.csproj
+++ b/src/api/ParticipantManager.API/ParticipantManager.API.csproj
@@ -19,15 +19,7 @@
     <PackageReference Include="Microsoft.IdentityModel.JsonWebTokens" Version="8.3.1" />
     <PackageReference Include="Microsoft.IdentityModel.Tokens" Version="8.3.1" />
     <PackageReference Include="System.Net.Http.Json" Version="8.0.1" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.11.0-beta.1" />
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/api/ParticipantManager.EventHandler/ParticipantManager.EventHandler.csproj
+++ b/src/api/ParticipantManager.EventHandler/ParticipantManager.EventHandler.csproj
@@ -13,15 +13,8 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.EventGrid" Version="3.4.2" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0" />
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0" />
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.23.0" />
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1" />
-    <PackageReference Include="OpenTelemetry.Api" Version="1.11.2" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.Runtime" Version="1.11.0" />
-    <PackageReference Include="OpenTelemetry.Instrumentation.SqlClient" Version="1.11.0-beta.1" />
+
   </ItemGroup>
   <ItemGroup>
     <None Update="host.json">

--- a/src/api/ParticipantManager.Experience.API/ParticipantManager.Experience.API.csproj
+++ b/src/api/ParticipantManager.Experience.API/ParticipantManager.Experience.API.csproj
@@ -9,7 +9,6 @@
   <ItemGroup>
     <FrameworkReference Include="Microsoft.AspNetCore.App"/>
     <PackageReference Include="Azure.Identity" Version="1.13.2"/>
-    <PackageReference Include="Azure.Monitor.OpenTelemetry.Exporter" Version="1.3.0"/>
     <PackageReference Include="Azure.Security.KeyVault.Secrets" Version="4.7.0"/>
     <PackageReference Include="AzureFunctions.Extensions.Middleware" Version="4.0.1"/>
     <PackageReference Include="Microsoft.ApplicationInsights" Version="2.23.0"/>
@@ -18,9 +17,6 @@
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore" Version="2.0.0"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Extensions.Http.AspNetCore.Analyzers" Version="1.0.3"/>
     <PackageReference Include="Microsoft.Azure.Functions.Worker.Sdk" Version="2.0.0"/>
-    <PackageReference Include="OpenTelemetry.Extensions.Hosting" Version="1.11.1"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.AspNetCore" Version="1.11.0"/>
-    <PackageReference Include="OpenTelemetry.Instrumentation.Http" Version="1.11.0"/>
     <PackageReference Include="Microsoft.ApplicationInsights.WorkerService" Version="2.22.0"/>
   </ItemGroup>
   <ItemGroup>

--- a/src/api/ParticipantManager.Shared/ParticipantManager.Shared.csproj
+++ b/src/api/ParticipantManager.Shared/ParticipantManager.Shared.csproj
@@ -7,6 +7,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Azure.Monitor.OpenTelemetry.AspNetCore" Version="1.2.0" />
     <PackageReference Include="AzureFunctions.Extensions.Middleware" Version="4.0.1" />
     <PackageReference Include="Flagsmith" Version="7.0.1" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.2" />


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

- Included Azure.Monitor.OpenTelemetry.AspNetCore in ParticipantManager.Shared
- Removed all other OpenTelemetry packages as they all appear to either be included as transient dependencies or not being used

## Context

Packages that are still included as transient dependencies:
- Azure.Monitor.OpenTelemetry.Exporter
- OpenTelemetry.Extensions.Hosting
- OpenTelemetry.Api
- OpenTelemetry.Instrumentation.AspNetCore
- OpenTelemetry.Instrumentation.Http

Packages that are no longer included:
- OpenTelemetry.Instrumentation.Runtime
- OpenTelemetry.Instrumentation.SqlClient

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [ ] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [ ] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
