### PR TITLE
fix: plural nouns for resource names in Experience API paths

### DIFF
--- a/src/api/ParticipantManager.Experience.API/Functions/GetParticipantIdFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/GetParticipantIdFunction.cs
@@ -15,7 +15,7 @@ public class GetParticipantIdFunction(
 {
     [Function("GetParticipantId")]
     public async Task<IActionResult> GetParticipantId(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "participant")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "participants/me/id")]
         HttpRequestData req)
     {
         try

--- a/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
@@ -15,7 +15,7 @@ public class ScreeningEligibilityFunction(
 {
     [Function("GetScreeningEligibility")]
     public async Task<IActionResult> GetScreeningEligibility(
-        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "participant/{participantId}/eligibility")]
+        [HttpTrigger(AuthorizationLevel.Anonymous, "get", Route = "participants/{participantId}/eligibility")]
         HttpRequestData req, Guid participantId)
     {
         try

--- a/src/api/ParticipantManager.Experience.API/openapi/openapi.yaml
+++ b/src/api/ParticipantManager.Experience.API/openapi/openapi.yaml
@@ -5,7 +5,7 @@ info:
   description: API used by Participant Manager front ends to present data.
 
 paths:
-  /participant:
+  /participants/me/id:
     get:
       summary: Get Participant ID
       description: Retrieves the Participant ID associated with the authenticated user.
@@ -86,7 +86,7 @@ paths:
         '500':
           description: Internal server error. This indicates an unexpected failure in the service.
 
-  /participant/{participantId}/eligibility:
+  /participants/{participantId}/eligibility:
     get:
       summary: Get Screening Eligibility
       description: Retrieves a list of screening pathways for which the authenticated user is eligible.

--- a/src/web/app/lib/fetchPatientData.test.ts
+++ b/src/web/app/lib/fetchPatientData.test.ts
@@ -55,7 +55,7 @@ describe("fetchPatientData", () => {
 
       expect(result).toEqual(mockEligibilityData);
       expect(global.fetch).toHaveBeenCalledWith(
-        "https://api.test/api/participant/test-participant-id/eligibility",
+        "https://api.test/api/participants/test-participant-id/eligibility",
         {
           method: "GET",
           headers: {
@@ -162,7 +162,7 @@ describe("fetchPatientData", () => {
 
       expect(result).toBe(mockParticipantId);
       expect(global.fetch).toHaveBeenCalledWith(
-        "https://api.test/api/participant",
+        "https://api.test/api/participants/me/id",
         {
           method: "GET",
           headers: {

--- a/src/web/app/lib/fetchPatientData.ts
+++ b/src/web/app/lib/fetchPatientData.ts
@@ -8,7 +8,7 @@ export async function fetchPatientScreeningEligibility(
   const correlationId = crypto.randomUUID();
 
   try {
-    const url = `${process.env.EXPERIENCE_API_URL}/api/participant/${session.user?.participantId}/eligibility`;
+    const url = `${process.env.EXPERIENCE_API_URL}/api/participants/${session.user?.participantId}/eligibility`;
     logger.info({ url, correlationId }, "Making eligibility API request");
     const response = await fetch(url, {
       method: "GET",
@@ -93,7 +93,7 @@ export async function fetchParticipantId(
   const correlationId = crypto.randomUUID();
 
   try {
-    const url = `${process.env.EXPERIENCE_API_URL}/api/participant`;
+    const url = `${process.env.EXPERIENCE_API_URL}/api/participants/me/id`;
     logger.info({ url, correlationId }, "Making get participant id API request");
     const response = await fetch(url, {
       method: "GET",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

participant should be pluralised - participants - in API paths.
Further, the endpoint that returns only an ID for the authenticated users has had its path changed to /api/participants/me/id

## Context

Adheres to REST path naming standards

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [x] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
