### PR TITLE
fix: refer to pathway type enrolments consistently

### DIFF
--- a/docs/solution-design/Solution_design.md
+++ b/docs/solution-design/Solution_design.md
@@ -153,7 +153,7 @@ sequenceDiagram
     ExperienceAPI->>ExperienceAPI: Extract NHS number from token
 
     ExperienceAPI->>ParticipantAPI: GET /participant/{id}/pathway-enrolments
-    ParticipantAPI->>Database: Query pathway enrolments
+    ParticipantAPI->>Database: Query pathway type enrolments
     Database-->>ParticipantAPI: Return enrolments
     ParticipantAPI->>ParticipantAPI: Validate NHS number matches
     ParticipantAPI-->>ExperienceAPI: Return enrolments

--- a/src/api/ParticipantManager.EventHandler/Functions/CreateEnrolmentHandler.cs
+++ b/src/api/ParticipantManager.EventHandler/Functions/CreateEnrolmentHandler.cs
@@ -59,7 +59,7 @@ public class CreateEnrolmentHandler
             ? await _crudApiClient.CreateParticipantAsync(pathwayParticipantDto)
             : participantDto.ParticipantId;
 
-        var pathwayEnrolmentDto = new CreatePathwayTypeEnrolmentDto
+        var pathwayTypeEnrolmentDto = new CreatePathwayTypeEnrolmentDto
         {
             ParticipantId = participantId.Value,
             PathwayTypeId = pathwayParticipantDto.PathwayTypeId,
@@ -67,13 +67,13 @@ public class CreateEnrolmentHandler
             ScreeningName = pathwayParticipantDto.ScreeningName
         };
 
-        var succeeded = await _crudApiClient.CreatePathwayTypeEnrolmentAsync(pathwayEnrolmentDto);
+        var succeeded = await _crudApiClient.CreatePathwayTypeEnrolmentAsync(pathwayTypeEnrolmentDto);
 
         if (!succeeded)
         {
             _logger.LogError(
                 "Failed to create PathwayTypeEnrolment for Participant: {Participant}, PathwayTypeName: {PathwayTypeName}",
-                pathwayEnrolmentDto.ParticipantId, pathwayEnrolmentDto.PathwayTypeName);
+                pathwayTypeEnrolmentDto.ParticipantId, pathwayTypeEnrolmentDto.PathwayTypeName);
             return;
         }
 

--- a/src/api/ParticipantManager.Experience.API/Functions/PathwayTypeEnrolmentFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/PathwayTypeEnrolmentFunction.cs
@@ -7,16 +7,16 @@ using ParticipantManager.Shared.Client;
 
 namespace ParticipantManager.Experience.API.Functions;
 
-public class PathwayEnrolmentFunction(
-    ILogger<PathwayEnrolmentFunction> logger,
+public class PathwayTypeEnrolmentFunction(
+    ILogger<PathwayTypeEnrolmentFunction> logger,
     ICrudApiClient crudApiClient,
     ITokenService tokenService,
     IFeatureFlagClient featureFlagClient)
 {
-    [Function("GetPathwayEnrolmentById")]
-    public async Task<IActionResult> GetPathwayEnrolmentById(
+    [Function("GetPathwayTypeEnrolmentById")]
+    public async Task<IActionResult> GetPathwayTypeEnrolmentById(
         [HttpTrigger(AuthorizationLevel.Anonymous, "get",
-            Route = "participants/{participantId}/pathwayenrolments/{enrolmentid}")]
+            Route = "participants/{participantId}/pathwaytypeenrolments/{enrolmentid}")]
         HttpRequestData req, Guid participantId, Guid enrolmentId)
     {
         try
@@ -38,15 +38,15 @@ public class PathwayEnrolmentFunction(
                 return new UnauthorizedResult();
             }
 
-            var pathwayEnrolment = await crudApiClient.GetPathwayEnrolmentByIdAsync(participantId, enrolmentId);
-            if (pathwayEnrolment == null)
+            var pathwayTypeEnrolment = await crudApiClient.GetPathwayTypeEnrolmentByIdAsync(participantId, enrolmentId);
+            if (pathwayTypeEnrolment == null)
             {
-                logger.LogError("Failed to find pathway enrolment for Request {@Request}",
+                logger.LogError("Failed to find pathway type enrolment for Request {@Request}",
                     new { NhsNumber = nhsNumber, EnrolmentId = enrolmentId });
                 return new NotFoundResult();
             }
 
-            if (pathwayEnrolment.Participant.NhsNumber != nhsNumber)
+            if (pathwayTypeEnrolment.Participant.NhsNumber != nhsNumber)
             {
                 logger.LogError("Logged in user does not have access to this record: {@ParticipantId}",
                     new { ParticipantId = participantId });
@@ -60,9 +60,9 @@ public class PathwayEnrolmentFunction(
                 return new ForbidResult();
             }
 
-            logger.LogInformation("Found pathway enrolment for Request {@Request}",
+            logger.LogInformation("Found pathway type enrolment for Request {@Request}",
                 new { NhsNumber = nhsNumber, EnrolmentId = enrolmentId });
-            return new OkObjectResult(pathwayEnrolment);
+            return new OkObjectResult(pathwayTypeEnrolment);
         }
         catch (Exception ex)
         {

--- a/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
+++ b/src/api/ParticipantManager.Experience.API/Functions/ScreeningEligibilityFunction.cs
@@ -41,10 +41,10 @@ public class ScreeningEligibilityFunction(
                 return new UnauthorizedResult();
             }
 
-            var pathwayEnrolments = await crudApiClient.GetPathwayEnrolmentsAsync(participantId);
+            var pathwayTypeEnrolments = await crudApiClient.GetPathwayTypeEnrolmentsAsync(participantId);
 
             //Check that logged in user has access to participant
-            if (pathwayEnrolments.Any(pe => pe.Participant.NhsNumber != nhsNumber))
+            if (pathwayTypeEnrolments.Any(pe => pe.Participant.NhsNumber != nhsNumber))
             {
                 logger.LogError("Logged in user does not have access to this record: {@ParticipantId}",
                     new { ParticipantId = participantId });
@@ -58,9 +58,9 @@ public class ScreeningEligibilityFunction(
                 return new ForbidResult();
             }
 
-            logger.LogInformation("Found pathway enrolments for Participant: {@ParticipantId}",
+            logger.LogInformation("Found pathway type enrolments for Participant: {@ParticipantId}",
                 new { ParticipantId = participantId });
-            return new OkObjectResult(pathwayEnrolments);
+            return new OkObjectResult(pathwayTypeEnrolments);
         }
         catch (Exception ex)
         {

--- a/src/api/ParticipantManager.Experience.API/openapi/openapi.yaml
+++ b/src/api/ParticipantManager.Experience.API/openapi/openapi.yaml
@@ -39,13 +39,13 @@ paths:
         '500':
           description: Internal server error. This indicates an unexpected failure in the service.
 
-  /participants/{participantId}/pathwayenrolments/{enrolmentId}:
+  /participants/{participantId}/pathwaytypeenrolments/{enrolmentId}:
     get:
-      summary: Get Pathway Enrolment by ID
-      description: Retrieves a single Pathway Enrolment for the authenticated user.
-      operationId: GetPathwayEnrolmentById
+      summary: Get Pathway Type Enrolment by ID
+      description: Retrieves a single Pathway Type Enrolment for the authenticated user.
+      operationId: GetPathwayTypeEnrolmentById
       tags:
-        - PathwayEnrolments
+        - PathwayTypeEnrolments
       security:
         - BearerAuth: []
       parameters:
@@ -65,7 +65,7 @@ paths:
           description: The ID of the enrolment.
       responses:
         '200':
-          description: Successfully retrieved the pathway enrolment.
+          description: Successfully retrieved the pathway type enrolment.
           content:
             application/json:
               schema:
@@ -111,7 +111,7 @@ paths:
               schema:
                 type: array
                 items:
-                  $ref: '#/components/schemas/PathwayEnrolmentDto'
+                  $ref: '#/components/schemas/PathwayTypeEnrolmentDto'
         '400':
           description: Bad request. Participant ID may be invalid.
           content:
@@ -159,7 +159,7 @@ components:
         participant:
           $ref: '#/components/schemas/ParticipantDto'
 
-    PathwayEnrolmentDto:
+    PathwayTypeEnrolmentDto:
       type: object
       properties:
         enrolmentId:

--- a/src/api/ParticipantManager.Shared/Client/CrudApiClient.cs
+++ b/src/api/ParticipantManager.Shared/Client/CrudApiClient.cs
@@ -10,29 +10,29 @@ public class CrudApiClient(
     HttpClient httpClient,
     JsonSerializerOptions jsonSerializerOptions) : ICrudApiClient
 {
-    public async Task<List<PathwayEnrolmentDto>> GetPathwayEnrolmentsAsync(Guid participantId)
+    public async Task<List<PathwayTypeEnrolmentDto>> GetPathwayTypeEnrolmentsAsync(Guid participantId)
     {
-        logger.LogInformation("GetPathwayEnrolmentsAsync");
+        logger.LogInformation("GetPathwayTypeEnrolmentsAsync");
         var uri = $"/api/pathwaytypeenrolments?participantId={participantId}";
 
         try
         {
             var response = await httpClient.GetAsync(uri);
             response.EnsureSuccessStatusCode();
-            return await response.Content.ReadFromJsonAsync<List<PathwayEnrolmentDto>>(jsonSerializerOptions)
+            return await response.Content.ReadFromJsonAsync<List<PathwayTypeEnrolmentDto>>(jsonSerializerOptions)
                 ?? throw new InvalidOperationException($"Deserialization returned null for: {uri}");
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "GetPathwayEnrolmentsAsync");
+            logger.LogError(ex, "GetPathwayTypeEnrolmentsAsync");
             throw new InvalidOperationException($"Error occurred whilst making request or deserialising object: {uri}",
                 ex);
         }
     }
 
-    public async Task<EnrolledPathwayDetailsDto?> GetPathwayEnrolmentByIdAsync(Guid participantId, Guid enrolmentId)
+    public async Task<EnrolledPathwayDetailsDto?> GetPathwayTypeEnrolmentByIdAsync(Guid participantId, Guid enrolmentId)
     {
-        logger.LogInformation("GetPathwayEnrolmentByIdAsync");
+        logger.LogInformation("GetPathwayTypeEnrolmentByIdAsync");
         var uri = $"/api/participants/{participantId}/pathwaytypeenrolments/{enrolmentId}";
 
         try
@@ -44,7 +44,7 @@ public class CrudApiClient(
         }
         catch (Exception ex)
         {
-            logger.LogError(ex, "GetPathwayEnrolmentByIdAsync");
+            logger.LogError(ex, "GetPathwayTypeEnrolmentByIdAsync");
             throw new InvalidOperationException($"Error occurred whilst making request or deserialising object: {uri}",
                 ex);
         }

--- a/src/api/ParticipantManager.Shared/Client/ICrudApiClient.cs
+++ b/src/api/ParticipantManager.Shared/Client/ICrudApiClient.cs
@@ -4,8 +4,8 @@ namespace ParticipantManager.Shared.Client;
 
 public interface ICrudApiClient
 {
-    Task<List<PathwayEnrolmentDto>> GetPathwayEnrolmentsAsync(Guid participantId);
-    Task<EnrolledPathwayDetailsDto?> GetPathwayEnrolmentByIdAsync(Guid participantId, Guid enrolmentId);
+    Task<List<PathwayTypeEnrolmentDto>> GetPathwayTypeEnrolmentsAsync(Guid participantId);
+    Task<EnrolledPathwayDetailsDto?> GetPathwayTypeEnrolmentByIdAsync(Guid participantId, Guid enrolmentId);
     Task<ParticipantDto?> GetParticipantByNhsNumberAsync(string nhsNumber);
     Task<Guid?> CreateParticipantAsync(ParticipantDto participantDto);
     Task<bool> CreatePathwayTypeEnrolmentAsync(CreatePathwayTypeEnrolmentDto pathwayTypeEnrolmentDto);

--- a/src/api/ParticipantManager.Shared/DTOs/PathwayTypeEnrolmentDto.cs
+++ b/src/api/ParticipantManager.Shared/DTOs/PathwayTypeEnrolmentDto.cs
@@ -1,6 +1,6 @@
 namespace ParticipantManager.Shared.DTOs;
 
-public record PathwayEnrolmentDto
+public record PathwayTypeEnrolmentDto
 {
     public required string EnrolmentId { get; set; }
     public required string ScreeningName { get; set; }

--- a/src/web/app/components/screeningPage.tsx
+++ b/src/web/app/components/screeningPage.tsx
@@ -2,7 +2,7 @@ import type { Metadata } from "next";
 import type { Session } from "next-auth";
 import type { PathwayItem } from "@/app/types";
 import { getAuthConfig } from "@/app/lib/auth";
-import { fetchPathwayEnrolment } from "@/app/lib/fetchPatientData";
+import { fetchPathwayTypeEnrolment } from "@/app/lib/fetchPatientData";
 import { logger } from "@/app/lib/logger";
 import Breadcrumb from "@/app/components/breadcrumb";
 import Card from "@/app/components/card";
@@ -16,20 +16,20 @@ export const generateMetadata = (screeningType: string): Metadata => ({
   title: `${screeningType} screening - ${process.env.SERVICE_NAME} - NHS`,
 });
 
-const getPathwayEnrolment = async (
+const getPathwayTypeEnrolment = async (
   session: Session | null,
   enrolmentId: string
 ): Promise<PathwayItem | null> => {
   if (!session?.user?.accessToken) {
-    logger.warn(`No access token found for pathway enrolment: ${enrolmentId}`);
+    logger.warn(`No access token found for pathway type enrolment: ${enrolmentId}`);
     return null;
   }
 
   try {
-    return await fetchPathwayEnrolment(session, enrolmentId);
+    return await fetchPathwayTypeEnrolment(session, enrolmentId);
   } catch (error) {
     logger.error(
-      ` Failed to get pathway enrolment data for: ${enrolmentId}`,
+      ` Failed to get pathway type enrolment data for: ${enrolmentId}`,
       error
     );
     return null;
@@ -45,8 +45,8 @@ export default async function ScreeningPage({
   const breadcrumbItems = [{ label: "Home", url: "/screening" }];
   const resolvedParams = await params;
   const enrolmentId = resolvedParams.enrolmentId;
-  const pathwayEnrolment = session?.user
-    ? await getPathwayEnrolment(session, enrolmentId)
+  const pathwayTypeEnrolment = session?.user
+    ? await getPathwayTypeEnrolment(session, enrolmentId)
     : null;
 
   return (
@@ -56,18 +56,18 @@ export default async function ScreeningPage({
         <div className="nhsuk-grid-row">
           <div className="nhsuk-grid-column-two-thirds">
             <h1>{screeningType} screening</h1>
-            {pathwayEnrolment?.nextActionDate ? (
+            {pathwayTypeEnrolment?.nextActionDate ? (
               <InsetText
-                text={`Your next ${pathwayEnrolment.screeningName} is due by`}
-                date={pathwayEnrolment.nextActionDate}
+                text={`Your next ${pathwayTypeEnrolment.screeningName} is due by`}
+                date={pathwayTypeEnrolment.nextActionDate}
               />
             ) : (
               <InsetText text="You have no upcoming invitations." />
             )}
-            {pathwayEnrolment?.infoUrl && (
+            {pathwayTypeEnrolment?.infoUrl && (
               <Card
-                title={`About ${pathwayEnrolment.screeningName}`}
-                url={pathwayEnrolment.infoUrl}
+                title={`About ${pathwayTypeEnrolment.screeningName}`}
+                url={pathwayTypeEnrolment.infoUrl}
               />
             )}
           </div>

--- a/src/web/app/lib/fetchPatientData.test.ts
+++ b/src/web/app/lib/fetchPatientData.test.ts
@@ -1,6 +1,6 @@
 import {
   fetchPatientScreeningEligibility,
-  fetchPathwayEnrolment,
+  fetchPathwayTypeEnrolment,
   fetchParticipantId,
 } from "@/app/lib/fetchPatientData";
 import { logger } from "@/app/lib/logger";
@@ -102,7 +102,7 @@ describe("fetchPatientData", () => {
     });
   });
 
-  describe("fetchPathwayEnrolment", () => {
+  describe("fetchPathwayTypeEnrolment", () => {
     const mockEnrolmentId = "test-enrolment";
     const mockPathwayData = {
       id: mockEnrolmentId,
@@ -115,11 +115,11 @@ describe("fetchPatientData", () => {
         json: () => Promise.resolve(mockPathwayData),
       });
 
-      const result = await fetchPathwayEnrolment(mockSession, mockEnrolmentId);
+      const result = await fetchPathwayTypeEnrolment(mockSession, mockEnrolmentId);
 
       expect(result).toEqual(mockPathwayData);
       expect(global.fetch).toHaveBeenCalledWith(
-        `https://api.test/api/participants/test-participant-id/pathwayenrolments/${mockEnrolmentId}`,
+        `https://api.test/api/participants/test-participant-id/pathwaytypeenrolments/${mockEnrolmentId}`,
         {
           method: "GET",
           headers: {
@@ -142,9 +142,9 @@ describe("fetchPatientData", () => {
       });
 
       await expect(
-        fetchPathwayEnrolment(mockSession, mockEnrolmentId)
+        fetchPathwayTypeEnrolment(mockSession, mockEnrolmentId)
       ).rejects.toThrow(
-        `Error fetching pathway enrolment data: ${errorMessage}`
+        `Error fetching pathway type enrolment data: ${errorMessage}`
       );
     });
   });

--- a/src/web/app/lib/fetchPatientData.ts
+++ b/src/web/app/lib/fetchPatientData.ts
@@ -44,7 +44,7 @@ export async function fetchPatientScreeningEligibility(
   }
 }
 
-export async function fetchPathwayEnrolment(
+export async function fetchPathwayTypeEnrolment(
   session: Session,
   enrolmentId: string
 ): Promise<PathwayResponse> {
@@ -52,7 +52,7 @@ export async function fetchPathwayEnrolment(
 
   try {
     const participantId = session.user?.participantId;
-    const url = `${process.env.EXPERIENCE_API_URL}/api/participants/${participantId}/pathwayenrolments/${enrolmentId}`;
+    const url = `${process.env.EXPERIENCE_API_URL}/api/participants/${participantId}/pathwaytypeenrolments/${enrolmentId}`;
     logger.info({ url, correlationId }, "Making pathway API request");
     logger.info(`session.user.participantId: ${session.user?.participantId}`);
     const response = await fetch(url, {
@@ -69,7 +69,7 @@ export async function fetchPathwayEnrolment(
         `Failed to get pathway data: ${response.statusText}`
       );
       throw new Error(
-        `Error fetching pathway enrolment data: ${response.statusText}`
+        `Error fetching pathway type enrolment data: ${response.statusText}`
       );
     }
 

--- a/tests/ParticipantManager.EventHandler.Tests/Functions/CreateEnrolmentHandlerTests.cs
+++ b/tests/ParticipantManager.EventHandler.Tests/Functions/CreateEnrolmentHandlerTests.cs
@@ -196,7 +196,7 @@ public class CreateEnrolmentHandlerTests
     }
 
     [Fact]
-    public async Task Run_WhenPathwayEnrolmentCreationFails_LogsErrorAndDoesNotSendEvent()
+    public async Task Run_WhenPathwayTypeEnrolmentCreationFails_LogsErrorAndDoesNotSendEvent()
     {
         // Arrange
         var cloudEvent = new CloudEvent("test-source", "test-event", _pathwayParticipantDto,

--- a/tests/ParticipantManager.Experience.API.Tests/Functions/PathwayTypeEnrolmentFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/Functions/PathwayTypeEnrolmentFunctionTests.cs
@@ -12,30 +12,30 @@ using ParticipantManager.Shared.DTOs;
 
 namespace ParticipantManager.Experience.API.Tests.Functions;
 
-public class PathwayEnrolmentFunctionTests
+public class PathwayTypeEnrolmentFunctionTests
 {
     private readonly Mock<ICrudApiClient> _crudApiClient = new();
-    private readonly PathwayEnrolmentFunction _function;
-    private readonly Mock<ILogger<PathwayEnrolmentFunction>> _loggerMock;
+    private readonly PathwayTypeEnrolmentFunction _function;
+    private readonly Mock<ILogger<PathwayTypeEnrolmentFunction>> _loggerMock;
     private readonly Mock<ITokenService> _mockTokenService = new();
     private readonly Mock<IFeatureFlagClient> _mockFeatureFlagClient = new();
     private readonly Guid _participantId = Guid.NewGuid();
     private readonly Guid _enrolmentId = Guid.NewGuid();
     private readonly HttpRequestData _request = CreateHttpRequest("");
 
-    public PathwayEnrolmentFunctionTests()
+    public PathwayTypeEnrolmentFunctionTests()
     {
-        _loggerMock = new Mock<ILogger<PathwayEnrolmentFunction>>();
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentByIdAsync(It.IsAny<Guid>(), It.IsAny<Guid>()).Result)
+        _loggerMock = new Mock<ILogger<PathwayTypeEnrolmentFunction>>();
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentByIdAsync(It.IsAny<Guid>(), It.IsAny<Guid>()).Result)
             .Returns(MockPathwayDetails);
-        _function = new PathwayEnrolmentFunction(_loggerMock.Object, _crudApiClient.Object, _mockTokenService.Object,
+        _function = new PathwayTypeEnrolmentFunction(_loggerMock.Object, _crudApiClient.Object, _mockTokenService.Object,
             _mockFeatureFlagClient.Object);
         _mockFeatureFlagClient.Setup(f => f.IsFeatureEnabledForParticipant(It.IsAny<string>(), It.IsAny<Guid>()))
             .ReturnsAsync(true);
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_InvalidToken_ReturnsUnauthorized()
+    public async Task GetPathwayTypeEnrolmentById_InvalidToken_ReturnsUnauthorized()
     {
         // Arrange
         _mockTokenService.Setup(s => s.ValidateToken(It.IsAny<HttpRequestData>()))
@@ -43,14 +43,14 @@ public class PathwayEnrolmentFunctionTests
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as UnauthorizedResult;
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId) as UnauthorizedResult;
 
         // Assert
         Assert.Equal(StatusCodes.Status401Unauthorized, response?.StatusCode);
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_NoNhsNumber_ReturnsUnauthorized()
+    public async Task GetPathwayTypeEnrolmentById_NoNhsNumber_ReturnsUnauthorized()
     {
         // Arrange
         var claims = new List<Claim>
@@ -68,14 +68,14 @@ public class PathwayEnrolmentFunctionTests
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as UnauthorizedResult;
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId) as UnauthorizedResult;
 
         // Assert
         Assert.Equal(StatusCodes.Status401Unauthorized, response?.StatusCode);
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_PathwayEnrolmentIsNull_ReturnsNotFound()
+    public async Task GetPathwayTypeEnrolmentById_PathwayTypeEnrolmentIsNull_ReturnsNotFound()
     {
         // Arrange
         var claims = new List<Claim>
@@ -90,19 +90,19 @@ public class PathwayEnrolmentFunctionTests
 
         _mockTokenService.Setup(s => s.ValidateToken(It.IsAny<HttpRequestData>()))
             .ReturnsAsync(AccessTokenResult.Success(principal));
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentByIdAsync(_participantId, _enrolmentId))
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentByIdAsync(_participantId, _enrolmentId))
             .Returns(Task.FromResult<EnrolledPathwayDetailsDto?>(null));
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as NotFoundResult;
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId) as NotFoundResult;
 
         // Assert
         Assert.Equal(StatusCodes.Status404NotFound, response?.StatusCode);
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_NhsNumberDoesNotMatch_ReturnsForbidden()
+    public async Task GetPathwayTypeEnrolmentById_NhsNumberDoesNotMatch_ReturnsForbidden()
     {
         // Arrange
         var claims = new List<Claim>
@@ -120,7 +120,7 @@ public class PathwayEnrolmentFunctionTests
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId);
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId);
 
         // Assert
         Assert.NotNull(response);
@@ -128,7 +128,7 @@ public class PathwayEnrolmentFunctionTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_FeatureToggleIsDisabled_ReturnsForbidden()
+    public async Task GetPathwayTypeEnrolmentById_FeatureToggleIsDisabled_ReturnsForbidden()
     {
         // Arrange
         var claims = new List<Claim>
@@ -147,7 +147,7 @@ public class PathwayEnrolmentFunctionTests
             .ReturnsAsync(false);
 
         // Act
-        var response = await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId);
+        var response = await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId);
 
         // Assert
         Assert.NotNull(response);
@@ -155,7 +155,7 @@ public class PathwayEnrolmentFunctionTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_ValidToken_ReturnsOk()
+    public async Task GetPathwayTypeEnrolmentById_ValidToken_ReturnsOk()
     {
         // Arrange
         var claims = new List<Claim>
@@ -172,16 +172,16 @@ public class PathwayEnrolmentFunctionTests
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as OkObjectResult;
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId) as OkObjectResult;
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, response?.StatusCode);
-        var pathwayEnrolmentDto = response?.Value as EnrolledPathwayDetailsDto;
-        Assert.Equal(pathwayEnrolmentDto?.ScreeningName, pathwayEnrolmentDto?.ScreeningName);
+        var pathwayTypeEnrolmentDto = response?.Value as EnrolledPathwayDetailsDto;
+        Assert.Equal(pathwayTypeEnrolmentDto?.ScreeningName, pathwayTypeEnrolmentDto?.ScreeningName);
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentById_ExceptionIsThrown_ReturnsBadRequest()
+    public async Task GetPathwayTypeEnrolmentById_ExceptionIsThrown_ReturnsBadRequest()
     {
         // Arrange
         var claims = new List<Claim>
@@ -195,12 +195,12 @@ public class PathwayEnrolmentFunctionTests
 
         _mockTokenService.Setup(s => s.ValidateToken(It.IsAny<HttpRequestData>()))
             .ReturnsAsync(AccessTokenResult.Success(principal));
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentByIdAsync(_participantId, _enrolmentId))
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentByIdAsync(_participantId, _enrolmentId))
             .ThrowsAsync(new Exception("Test exception message"));
 
         // Act
         var response =
-            await _function.GetPathwayEnrolmentById(_request, _participantId, _enrolmentId) as BadRequestObjectResult;
+            await _function.GetPathwayTypeEnrolmentById(_request, _participantId, _enrolmentId) as BadRequestObjectResult;
 
         // Assert
         Assert.Equal(StatusCodes.Status400BadRequest, response?.StatusCode);

--- a/tests/ParticipantManager.Experience.API.Tests/Functions/ScreeningEligibilityFunctionTests.cs
+++ b/tests/ParticipantManager.Experience.API.Tests/Functions/ScreeningEligibilityFunctionTests.cs
@@ -25,8 +25,8 @@ public class ScreeningEligibilityFunctionTests
     public ScreeningEligibilityFunctionTests()
     {
         _loggerMock = new Mock<ILogger<ScreeningEligibilityFunction>>();
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentsAsync(It.IsAny<Guid>()).Result)
-            .Returns(MockListPathwayEnrolments);
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentsAsync(It.IsAny<Guid>()).Result)
+            .Returns(MockListPathwayTypeEnrolments);
         _function = new ScreeningEligibilityFunction(_loggerMock.Object, _crudApiClient.Object,
             _mockTokenService.Object,
             _mockFeatureFlagClient.Object);
@@ -97,7 +97,7 @@ public class ScreeningEligibilityFunctionTests
     }
 
     [Fact]
-    public async Task GetScreeningEligibility_PathwayEnrolmentsReturnsEmptyCollection_ReturnsOk()
+    public async Task GetScreeningEligibility_PathwayTypeEnrolmentsReturnsEmptyCollection_ReturnsOk()
     {
         // Arrange
         var claims = new List<Claim>
@@ -112,7 +112,7 @@ public class ScreeningEligibilityFunctionTests
 
         _mockTokenService.Setup(s => s.ValidateToken(It.IsAny<HttpRequestData>()))
             .ReturnsAsync(AccessTokenResult.Success(principal));
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentsAsync(_participantId)).ReturnsAsync([]);
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentsAsync(_participantId)).ReturnsAsync([]);
 
         // Act
         var response = await _function.GetScreeningEligibility(_request, _participantId) as OkObjectResult;
@@ -197,7 +197,7 @@ public class ScreeningEligibilityFunctionTests
 
         // Assert
         Assert.Equal(StatusCodes.Status200OK, response?.StatusCode);
-        var enrollments = response?.Value as List<PathwayEnrolmentDto>;
+        var enrollments = response?.Value as List<PathwayTypeEnrolmentDto>;
         Assert.NotNull(enrollments);
         Assert.Equal(2, enrollments.Count);
     }
@@ -218,7 +218,7 @@ public class ScreeningEligibilityFunctionTests
 
         _mockTokenService.Setup(s => s.ValidateToken(It.IsAny<HttpRequestData>()))
             .ReturnsAsync(AccessTokenResult.Success(principal));
-        _crudApiClient.Setup(s => s.GetPathwayEnrolmentsAsync(_participantId))
+        _crudApiClient.Setup(s => s.GetPathwayTypeEnrolmentsAsync(_participantId))
             .ThrowsAsync(new Exception("Test exception message"));
 
         // Act
@@ -239,9 +239,9 @@ public class ScreeningEligibilityFunctionTests
         return request.Object;
     }
 
-    private List<PathwayEnrolmentDto> MockListPathwayEnrolments()
+    private List<PathwayTypeEnrolmentDto> MockListPathwayTypeEnrolments()
     {
-        return new List<PathwayEnrolmentDto>
+        return new List<PathwayTypeEnrolmentDto>
         {
             new()
             {

--- a/tests/ParticipantManager.Shared.Tests/Client/CrudApiClientTests.cs
+++ b/tests/ParticipantManager.Shared.Tests/Client/CrudApiClientTests.cs
@@ -34,7 +34,7 @@ public class CrudApiClientTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentsAsync_ShouldReturnEnrolments_WhenResponseIsSuccessful()
+    public async Task GetPathwayTypeEnrolmentsAsync_ShouldReturnEnrolments_WhenResponseIsSuccessful()
     {
         // Arrange
         var expectedEnrolments = new List<PathwayTypeEnrolment>()
@@ -62,7 +62,7 @@ public class CrudApiClientTests
             expectedEnrolments);
 
         // Act
-        var result = await _client.GetPathwayEnrolmentsAsync(_participantId);
+        var result = await _client.GetPathwayTypeEnrolmentsAsync(_participantId);
 
         // Assert
         Assert.NotNull(result);
@@ -72,15 +72,15 @@ public class CrudApiClientTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentsAsync_ShouldReturnInvalidOperationException_WhenDeserializationReturnsNull()
+    public async Task GetPathwayTypeEnrolmentsAsync_ShouldReturnInvalidOperationException_WhenDeserializationReturnsNull()
     {
         // Arrange
-        _mockHttpMessageHandler.SetupRequest<List<PathwayEnrolmentDto>>(HttpMethod.Get,
+        _mockHttpMessageHandler.SetupRequest<List<PathwayTypeEnrolmentDto>>(HttpMethod.Get,
             $"/api/pathwaytypeenrolments?participantId={_participantId}",
             null!);
 
         // Act
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _client.GetPathwayEnrolmentsAsync(_participantId));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _client.GetPathwayTypeEnrolmentsAsync(_participantId));
 
         // Assert
         Assert.NotNull(ex.InnerException);
@@ -89,7 +89,7 @@ public class CrudApiClientTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentByIdAsync_ShouldReturnEnrolment_WhenResponseIsSuccessful()
+    public async Task GetPathwayTypeEnrolmentByIdAsync_ShouldReturnEnrolment_WhenResponseIsSuccessful()
     {
         // Arrange
         var enrolmentId = Guid.NewGuid();
@@ -110,7 +110,7 @@ public class CrudApiClientTests
             $"/api/participants/{_participantId}/pathwaytypeenrolments/{enrolmentId}", expectedEnrolment);
 
         // Act
-        var result = await _client.GetPathwayEnrolmentByIdAsync(_participantId, enrolmentId);
+        var result = await _client.GetPathwayTypeEnrolmentByIdAsync(_participantId, enrolmentId);
 
         // Assert
         Assert.NotNull(result);
@@ -118,7 +118,7 @@ public class CrudApiClientTests
     }
 
     [Fact]
-    public async Task GetPathwayEnrolmentByIdAsync_ShouldThrowInvalidOperationException_WhenEnrolmentNotFound()
+    public async Task GetPathwayTypeEnrolmentByIdAsync_ShouldThrowInvalidOperationException_WhenEnrolmentNotFound()
     {
         // Arrange
         var enrolmentId = Guid.NewGuid();
@@ -126,7 +126,7 @@ public class CrudApiClientTests
         _mockHttpMessageHandler.SetupRequest(HttpMethod.Get, uri, HttpStatusCode.NotFound);
 
         // Act
-        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _client.GetPathwayEnrolmentByIdAsync(_participantId, enrolmentId));
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(() => _client.GetPathwayTypeEnrolmentByIdAsync(_participantId, enrolmentId));
 
         // Assert
         Assert.NotNull(ex.InnerException);


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

The codebase used a mixture of the terms "pathway enrolment" and "pathway type enrolment". Modified to use the latter consistently.

## Context

Naming things consistently aids understanding.

## Type of changes


- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [x] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
