### PR TITLE
fix: token service should validate token expiry time

### DIFF
--- a/src/api/ParticipantManager.Experience.API/Services/TokenService.cs
+++ b/src/api/ParticipantManager.Experience.API/Services/TokenService.cs
@@ -38,8 +38,7 @@ public class TokenService(IJwksProvider jwksProvider, ILogger<TokenService> logg
                     ValidateIssuer = true,
                     RequireSignedTokens = false,
                     ValidateIssuerSigningKey = false,
-                    ValidateLifetime = false,
-                    //TODO Make sure this is set to true
+                    ValidateLifetime = true,
                     IssuerSigningKeys = await jwksProvider.GetSigningKeysAsync()
                 };
                 // Validate the token


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Following the work done on the frontend in [PR25](https://github.com/NHSDigital/dtos-participant-manager/pull/25) to refresh expired tokens, we can now validate token expiry on the backend.

## Context

For security purposes, the backend token service should validate that tokens presented to it have not expired.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
