### PR TITLE
fix: suppress hardcoded pathway url warning. Change fallback URL.

### DIFF
--- a/src/api/ParticipantManager.Shared/DTOs/PathwayInfoUrlMapper.cs
+++ b/src/api/ParticipantManager.Shared/DTOs/PathwayInfoUrlMapper.cs
@@ -2,15 +2,17 @@ namespace ParticipantManager.Shared.DTOs;
 
 public static class PathwayInfoUrlMapper
 {
+    #pragma warning disable S1075 // URIs should not be hardcoded
     private static readonly Dictionary<string, string> PathwayUrls = new()
     {
         { "Breast Screening Routine", "https://www.nhs.uk/conditions/breast-screening-mammogram/" },
         { "Cervical Screening Routine", "https://www.nhs.uk/conditions/cervical-screening/" },
         { "Bowel Screening Routine", "https://www.nhs.uk/conditions/bowel-cancer/" }
     };
+    #pragma warning restore S1075
 
     public static string GetUrl(string pathwayName)
     {
-        return PathwayUrls.TryGetValue(pathwayName, out var url) ? url : "https://example.com/default-screening";
+        return PathwayUrls.TryGetValue(pathwayName, out var url) ? url : "https://www.nhs.uk/conditions/nhs-screening/";
     }
 }


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

Suppressed SonarQube warnings about hardcoded URLs.
The URLs in PathwayInfoUrlMapper are deliberately hardcoded and static across environments.

Also, changed the default fallback URL from a nonexistent example.com address to the https://www.nhs.uk/conditions/nhs-screening/ page

## Context

Suppresses false positive SonarQube issues.
Allows fallback to sensible default nhs.uk screening guidance if PathwayInfoUrlMapper is not updated with a URL for an unanticipated pathway name.

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
