### PR TITLE
chore: bump dependencies and include webpack config

### DIFF
--- a/src/web/next.config.mjs
+++ b/src/web/next.config.mjs
@@ -6,6 +6,14 @@ const nextConfig = {
     quietDeps: true,
     includePaths: ["./node_modules/nhsuk-frontend"],
   },
+  webpack: (config) => {
+    config.externals = [
+      ...(config.externals || []),
+      "require-in-the-middle",
+      "@azure/functions-core",
+    ];
+    return config;
+  },
 };
 
 export default nextConfig;

--- a/src/web/package-lock.json
+++ b/src/web/package-lock.json
@@ -41,7 +41,7 @@
         "@types/react": "19.0.12",
         "@types/react-dom": "19.0.4",
         "dotenv": "^16.4.7",
-        "eslint": "^9.23.0",
+        "eslint": "^9.24.0",
         "eslint-config-next": "15.2.4",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
@@ -1075,9 +1075,9 @@
       }
     },
     "node_modules/@eslint/config-array": {
-      "version": "0.19.2",
-      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.19.2.tgz",
-      "integrity": "sha512-GNKqxfHG2ySmJOBSHg7LxeUx4xpuCoFjacmlCoYWEbaPXLwvfIjixRI12xCQZeULksQb23uiA8F40w5TojpV7w==",
+      "version": "0.20.0",
+      "resolved": "https://registry.npmjs.org/@eslint/config-array/-/config-array-0.20.0.tgz",
+      "integrity": "sha512-fxlS1kkIjx8+vy2SjuCB94q3htSNrufYTXubwiBFeaQHbH6Ipi43gFJq2zCMt6PHhImH3Xmr0NksKDvchWlpQQ==",
       "dev": true,
       "dependencies": {
         "@eslint/object-schema": "^2.1.6",
@@ -1133,9 +1133,9 @@
       }
     },
     "node_modules/@eslint/js": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.23.0.tgz",
-      "integrity": "sha512-35MJ8vCPU0ZMxo7zfev2pypqTwWTofFZO6m4KAtdoFhRpLJUpHTZZ+KB3C7Hb1d7bULYwO4lJXGCi5Se+8OMbw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/@eslint/js/-/js-9.24.0.tgz",
+      "integrity": "sha512-uIY/y3z0uvOGX8cp1C2fiC4+ZmBhp6yZWkojtHL1YEMnRt1Y63HB9TM17proGEmeG7HeUY+UP36F0aknKYTpYA==",
       "dev": true,
       "engines": {
         "node": "^18.18.0 || ^20.9.0 || >=21.1.0"
@@ -5927,18 +5927,18 @@
       }
     },
     "node_modules/eslint": {
-      "version": "9.23.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.23.0.tgz",
-      "integrity": "sha512-jV7AbNoFPAY1EkFYpLq5bslU9NLNO8xnEeQXwErNibVryjk67wHVmddTBilc5srIttJDBrB0eMHKZBFbSIABCw==",
+      "version": "9.24.0",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-9.24.0.tgz",
+      "integrity": "sha512-eh/jxIEJyZrvbWRe4XuVclLPDYSYYYgLy5zXGGxD6j8zjSAxFEzI2fL/8xNq6O2yKqVt+eF2YhV+hxjV6UKXwQ==",
       "dev": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.12.1",
-        "@eslint/config-array": "^0.19.2",
+        "@eslint/config-array": "^0.20.0",
         "@eslint/config-helpers": "^0.2.0",
         "@eslint/core": "^0.12.0",
         "@eslint/eslintrc": "^3.3.1",
-        "@eslint/js": "9.23.0",
+        "@eslint/js": "9.24.0",
         "@eslint/plugin-kit": "^0.2.7",
         "@humanfs/node": "^0.16.6",
         "@humanwhocodes/module-importer": "^1.0.1",

--- a/src/web/package.json
+++ b/src/web/package.json
@@ -52,7 +52,7 @@
     "@types/react": "19.0.12",
     "@types/react-dom": "19.0.4",
     "dotenv": "^16.4.7",
-    "eslint": "^9.23.0",
+    "eslint": "^9.24.0",
     "eslint-config-next": "15.2.4",
     "jest": "^29.7.0",
     "jest-environment-jsdom": "^29.7.0",


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

chore: bump dependencies and include webpack config

The `experimental` section is no longer required in Next.js 15; https://nextjs.org/blog/next-15#instrumentationjs-stable
and https://nextjs.org/docs/app/api-reference/config/next-config-js/serverExternalPackages

## Context

<!-- Why is this change required? What problem does it solve? -->

## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [ ] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
