### PR TITLE
fix: DTOSS-8363 Full automation of App Service certificate bindings

### DIFF
--- a/.azuredevops/pipelines/cd-infrastructure-dev-audit.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-dev-audit.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: aa2910e39d7212b19221ebba408dd3c949804797
+      ref: 0f1c4c653749b39e601ac6ee37021027433a1054
       endpoint: NHSDigital
 
 variables:

--- a/.azuredevops/pipelines/cd-infrastructure-dev-core.yaml
+++ b/.azuredevops/pipelines/cd-infrastructure-dev-core.yaml
@@ -14,7 +14,7 @@ resources:
     - repository: dtos-devops-templates
       type: github
       name: NHSDigital/dtos-devops-templates
-      ref: aa2910e39d7212b19221ebba408dd3c949804797
+      ref: 0f1c4c653749b39e601ac6ee37021027433a1054
       endpoint: NHSDigital
 
 variables:

--- a/infrastructure/tf-core/app_service_plan.tf
+++ b/infrastructure/tf-core/app_service_plan.tf
@@ -30,41 +30,38 @@ module "app-service-plan" {
 
   log_analytics_workspace_id                        = data.terraform_remote_state.audit.outputs.log_analytics_workspace_id[local.primary_region]
   monitor_diagnostic_setting_appserviceplan_metrics = local.monitor_diagnostic_setting_appserviceplan_metrics
-
-  os_type  = lookup(each.value, "os_type", var.app_service_plan.os_type)
-  sku_name = lookup(each.value, "sku_name", var.app_service_plan.sku_name)
-
-  vnet_integration_subnet_id = module.subnets["${module.regions_config[each.value.region].names.subnet}-apps"].id
-
-  wildcard_ssl_cert_name                           = each.value.wildcard_ssl_cert_key
-  wildcard_ssl_cert_pfx_blob_key_vault_secret_name = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault_certificates["${each.value.wildcard_ssl_cert_key}-${each.value.region}"].pfx_blob_secret_name : null
-  wildcard_ssl_cert_key_vault_id                   = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault["${each.value.region}"].key_vault_id : null
+  os_type                                           = lookup(each.value, "os_type", var.app_service_plan.os_type)
+  sku_name                                          = lookup(each.value, "sku_name", var.app_service_plan.sku_name)
+  vnet_integration_subnet_id                        = module.subnets["${module.regions_config[each.value.region].names.subnet}-apps"].id
+  wildcard_ssl_cert_name                            = each.value.wildcard_ssl_cert_key
+  wildcard_ssl_cert_pfx_blob_key_vault_secret_name  = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault_certificates["${each.value.wildcard_ssl_cert_key}-${each.value.region}"].pfx_blob_secret_name : null
+  wildcard_ssl_cert_key_vault_id                    = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault["${each.value.region}"].key_vault_id : null
 
   tags = var.tags
 
   ## autoscale rule
-  metric = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.metric, var.app_service_plan.autoscale.memory_percentage.metric) : var.app_service_plan.autoscale.memory_percentage.metric
+  metric = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.metric, var.app_service_plan.autoscale.scaling_rule.metric) : var.app_service_plan.autoscale.scaling_rule.metric
 
-  capacity_min = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.capacity_min, var.app_service_plan.autoscale.memory_percentage.capacity_min) : var.app_service_plan.autoscale.memory_percentage.capacity_min
-  capacity_max = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.capacity_max, var.app_service_plan.autoscale.memory_percentage.capacity_max) : var.app_service_plan.autoscale.memory_percentage.capacity_max
-  capacity_def = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.capacity_def, var.app_service_plan.autoscale.memory_percentage.capacity_def) : var.app_service_plan.autoscale.memory_percentage.capacity_def
+  capacity_min = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.capacity_min, var.app_service_plan.autoscale.scaling_rule.capacity_min) : var.app_service_plan.autoscale.scaling_rule.capacity_min
+  capacity_max = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.capacity_max, var.app_service_plan.autoscale.scaling_rule.capacity_max) : var.app_service_plan.autoscale.scaling_rule.capacity_max
+  capacity_def = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.capacity_def, var.app_service_plan.autoscale.scaling_rule.capacity_def) : var.app_service_plan.autoscale.scaling_rule.capacity_def
 
-  time_grain       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.time_grain, var.app_service_plan.autoscale.memory_percentage.time_grain) : var.app_service_plan.autoscale.memory_percentage.time_grain
-  statistic        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.statistic, var.app_service_plan.autoscale.memory_percentage.statistic) : var.app_service_plan.autoscale.memory_percentage.statistic
-  time_window      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.time_window, var.app_service_plan.autoscale.memory_percentage.time_window) : var.app_service_plan.autoscale.memory_percentage.time_window
-  time_aggregation = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.time_aggregation, var.app_service_plan.autoscale.memory_percentage.time_aggregation) : var.app_service_plan.autoscale.memory_percentage.time_aggregation
+  time_grain       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.time_grain, var.app_service_plan.autoscale.scaling_rule.time_grain) : var.app_service_plan.autoscale.scaling_rule.time_grain
+  statistic        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.statistic, var.app_service_plan.autoscale.scaling_rule.statistic) : var.app_service_plan.autoscale.scaling_rule.statistic
+  time_window      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.time_window, var.app_service_plan.autoscale.scaling_rule.time_window) : var.app_service_plan.autoscale.scaling_rule.time_window
+  time_aggregation = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.time_aggregation, var.app_service_plan.autoscale.scaling_rule.time_aggregation) : var.app_service_plan.autoscale.scaling_rule.time_aggregation
 
-  inc_operator        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_operator, var.app_service_plan.autoscale.memory_percentage.inc_operator) : var.app_service_plan.autoscale.memory_percentage.inc_operator
-  inc_threshold       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_threshold, var.app_service_plan.autoscale.memory_percentage.inc_threshold) : var.app_service_plan.autoscale.memory_percentage.inc_threshold
-  inc_scale_direction = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_scale_direction, var.app_service_plan.autoscale.memory_percentage.inc_scale_direction) : var.app_service_plan.autoscale.memory_percentage.inc_scale_direction
-  inc_scale_type      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_scale_type, var.app_service_plan.autoscale.memory_percentage.inc_scale_type) : var.app_service_plan.autoscale.memory_percentage.inc_scale_type
-  inc_scale_value     = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_scale_value, var.app_service_plan.autoscale.memory_percentage.inc_scale_value) : var.app_service_plan.autoscale.memory_percentage.inc_scale_value
-  inc_scale_cooldown  = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.inc_scale_cooldown, var.app_service_plan.autoscale.memory_percentage.inc_scale_cooldown) : var.app_service_plan.autoscale.memory_percentage.inc_scale_cooldown
+  inc_operator        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_operator, var.app_service_plan.autoscale.scaling_rule.inc_operator) : var.app_service_plan.autoscale.scaling_rule.inc_operator
+  inc_threshold       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_threshold, var.app_service_plan.autoscale.scaling_rule.inc_threshold) : var.app_service_plan.autoscale.scaling_rule.inc_threshold
+  inc_scale_direction = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_scale_direction, var.app_service_plan.autoscale.scaling_rule.inc_scale_direction) : var.app_service_plan.autoscale.scaling_rule.inc_scale_direction
+  inc_scale_type      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_scale_type, var.app_service_plan.autoscale.scaling_rule.inc_scale_type) : var.app_service_plan.autoscale.scaling_rule.inc_scale_type
+  inc_scale_value     = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_scale_value, var.app_service_plan.autoscale.scaling_rule.inc_scale_value) : var.app_service_plan.autoscale.scaling_rule.inc_scale_value
+  inc_scale_cooldown  = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.inc_scale_cooldown, var.app_service_plan.autoscale.scaling_rule.inc_scale_cooldown) : var.app_service_plan.autoscale.scaling_rule.inc_scale_cooldown
 
-  dec_operator        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_operator, var.app_service_plan.autoscale.memory_percentage.dec_operator) : var.app_service_plan.autoscale.memory_percentage.dec_operator
-  dec_threshold       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_threshold, var.app_service_plan.autoscale.memory_percentage.dec_threshold) : var.app_service_plan.autoscale.memory_percentage.dec_threshold
-  dec_scale_direction = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_scale_direction, var.app_service_plan.autoscale.memory_percentage.dec_scale_direction) : var.app_service_plan.autoscale.memory_percentage.dec_scale_direction
-  dec_scale_type      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_scale_type, var.app_service_plan.autoscale.memory_percentage.dec_scale_type) : var.app_service_plan.autoscale.memory_percentage.dec_scale_type
-  dec_scale_value     = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_scale_value, var.app_service_plan.autoscale.memory_percentage.dec_scale_value) : var.app_service_plan.autoscale.memory_percentage.dec_scale_value
-  dec_scale_cooldown  = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.memory_percentage.dec_scale_cooldown, var.app_service_plan.autoscale.memory_percentage.dec_scale_cooldown) : var.app_service_plan.autoscale.memory_percentage.dec_scale_cooldown
+  dec_operator        = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_operator, var.app_service_plan.autoscale.scaling_rule.dec_operator) : var.app_service_plan.autoscale.scaling_rule.dec_operator
+  dec_threshold       = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_threshold, var.app_service_plan.autoscale.scaling_rule.dec_threshold) : var.app_service_plan.autoscale.scaling_rule.dec_threshold
+  dec_scale_direction = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_scale_direction, var.app_service_plan.autoscale.scaling_rule.dec_scale_direction) : var.app_service_plan.autoscale.scaling_rule.dec_scale_direction
+  dec_scale_type      = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_scale_type, var.app_service_plan.autoscale.scaling_rule.dec_scale_type) : var.app_service_plan.autoscale.scaling_rule.dec_scale_type
+  dec_scale_value     = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_scale_value, var.app_service_plan.autoscale.scaling_rule.dec_scale_value) : var.app_service_plan.autoscale.scaling_rule.dec_scale_value
+  dec_scale_cooldown  = each.value.autoscale_override != null ? coalesce(each.value.autoscale_override.scaling_rule.dec_scale_cooldown, var.app_service_plan.autoscale.scaling_rule.dec_scale_cooldown) : var.app_service_plan.autoscale.scaling_rule.dec_scale_cooldown
 }

--- a/infrastructure/tf-core/app_service_plan.tf
+++ b/infrastructure/tf-core/app_service_plan.tf
@@ -36,9 +36,9 @@ module "app-service-plan" {
 
   vnet_integration_subnet_id = module.subnets["${module.regions_config[each.value.region].names.subnet}-apps"].id
 
-  wildcard_ssl_cert_key_vault_id        = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault["${each.value.region}"].key_vault_id : null
-  wildcard_ssl_cert_key_vault_secret_id = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault_certificates["${each.value.wildcard_ssl_cert_key}-${each.value.region}"].versionless_secret_id : null
-  wildcard_ssl_cert_name                = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault_certificates["${each.value.wildcard_ssl_cert_key}-${each.value.region}"].name : null
+  wildcard_ssl_cert_name                           = each.value.wildcard_ssl_cert_key
+  wildcard_ssl_cert_pfx_blob_key_vault_secret_name = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault_certificates["${each.value.wildcard_ssl_cert_key}-${each.value.region}"].pfx_blob_secret_name : null
+  wildcard_ssl_cert_key_vault_id                   = each.value.wildcard_ssl_cert_key != null ? data.terraform_remote_state.hub.outputs.key_vault["${each.value.region}"].key_vault_id : null
 
   tags = var.tags
 

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -103,7 +103,7 @@ app_service_plan = {
   vnet_integration_enabled = true
 
   autoscale = {
-    memory_percentage = {
+    scaling_rule = {
       metric = "MemoryPercentage"
 
       capacity_min = "1"

--- a/infrastructure/tf-core/environments/development.tfvars
+++ b/infrastructure/tf-core/environments/development.tfvars
@@ -134,7 +134,7 @@ app_service_plan = {
   instances = {
     Default = {}
     WebApp = {
-      #      wildcard_ssl_cert_key = "nationalscreening_wildcard"
+      wildcard_ssl_cert_key = "screening_wildcard" # from keys in lets_encrypt_certificates map in Hub tfvars
     }
     # BIAnalyticsDataService       = {}
     # BIAnalyticsService           = {}
@@ -245,12 +245,12 @@ linux_web_app = {
     FrontEndUi = {
       name_suffix          = "nextjs-frontend"
       app_service_plan_key = "WebApp"
-      custom_domains       = ["www-dev.non-live.nationalscreening.nhs.uk"]
+      custom_domains       = ["www-dev.non-live.screening.nhs.uk"]
       env_vars_static = {
         AUTH_NHSLOGIN_CLIENT_ID  = "screening participant manager"
         AUTH_NHSLOGIN_ISSUER_URL = "https://auth.sandpit.signin.nhs.uk"
         AUTH_TRUST_HOST          = true
-        NEXTAUTH_URL             = "https://www-dev.non-live.nationalscreening.nhs.uk/api/auth"
+        NEXTAUTH_URL             = "https://www-dev.non-live.screening.nhs.uk/api/auth"
         SERVICE_NAME             = "Manage your screening"
       }
       env_vars_from_key_vault = [

--- a/infrastructure/tf-core/environments/int.tfvars
+++ b/infrastructure/tf-core/environments/int.tfvars
@@ -134,7 +134,7 @@ app_service_plan = {
   instances = {
     Default = {}
     WebApp = {
-      wildcard_ssl_cert_key = "nationalscreening_wildcard"
+      wildcard_ssl_cert_key = "screening_wildcard" # from keys in lets_encrypt_certificates map in Hub tfvars
     }
     # BIAnalyticsDataService       = {}
     # BIAnalyticsService           = {}
@@ -245,12 +245,12 @@ linux_web_app = {
     FrontEndUi = {
       name_suffix          = "nextjs-frontend"
       app_service_plan_key = "WebApp"
-      custom_domains       = ["www-int.non-live.nationalscreening.nhs.uk"]
+      custom_domains       = ["www-int.non-live.screening.nhs.uk"]
       env_vars_static = {
         AUTH_NHSLOGIN_CLIENT_ID  = "screening participant manager"
         AUTH_NHSLOGIN_ISSUER_URL = "https://auth.sandpit.signin.nhs.uk"
         AUTH_TRUST_HOST          = true
-        NEXTAUTH_URL             = "https://www-int.non-live.nationalscreening.nhs.uk/api/auth"
+        NEXTAUTH_URL             = "https://www-int.non-live.screening.nhs.uk/api/auth"
         SERVICE_NAME             = "Manage your screening"
       }
       env_vars_from_key_vault = [

--- a/infrastructure/tf-core/environments/int.tfvars
+++ b/infrastructure/tf-core/environments/int.tfvars
@@ -103,7 +103,7 @@ app_service_plan = {
   vnet_integration_enabled = true
 
   autoscale = {
-    memory_percentage = {
+    scaling_rule = {
       metric = "MemoryPercentage"
 
       capacity_min = "1"

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -103,7 +103,7 @@ app_service_plan = {
   vnet_integration_enabled = true
 
   autoscale = {
-    memory_percentage = {
+    scaling_rule = {
       metric = "MemoryPercentage"
 
       capacity_min = "1"

--- a/infrastructure/tf-core/environments/nft.tfvars
+++ b/infrastructure/tf-core/environments/nft.tfvars
@@ -134,7 +134,7 @@ app_service_plan = {
   instances = {
     Default = {}
     WebApp = {
-      wildcard_ssl_cert_key = "nationalscreening_wildcard"
+      wildcard_ssl_cert_key = "screening_wildcard" # from keys in lets_encrypt_certificates map in Hub tfvars
     }
     # BIAnalyticsDataService       = {}
     # BIAnalyticsService           = {}
@@ -245,12 +245,12 @@ linux_web_app = {
     FrontEndUi = {
       name_suffix          = "nextjs-frontend"
       app_service_plan_key = "WebApp"
-      custom_domains       = ["www-nft.non-live.nationalscreening.nhs.uk"]
+      custom_domains       = ["www-nft.non-live.screening.nhs.uk"]
       env_vars_static = {
         AUTH_NHSLOGIN_CLIENT_ID  = "screening participant manager"
         AUTH_NHSLOGIN_ISSUER_URL = "https://auth.sandpit.signin.nhs.uk"
         AUTH_TRUST_HOST          = true
-        NEXTAUTH_URL             = "https://www-nft.non-live.nationalscreening.nhs.uk/api/auth"
+        NEXTAUTH_URL             = "https://www-nft.non-live.screening.nhs.uk/api/auth"
         SERVICE_NAME             = "Manage your screening"
       }
       env_vars_from_key_vault = [

--- a/infrastructure/tf-core/variables.tf
+++ b/infrastructure/tf-core/variables.tf
@@ -73,7 +73,7 @@ variable "app_service_plan" {
     vnet_integration_enabled = optional(bool, false)
 
     autoscale = object({
-      memory_percentage = object({
+      scaling_rule = object({
         metric              = optional(string)
         capacity_min        = optional(string)
         capacity_max        = optional(string)
@@ -99,7 +99,7 @@ variable "app_service_plan" {
 
     instances = map(object({
       autoscale_override = optional(object({
-        memory_percentage = object({
+        scaling_rule = object({
           metric              = optional(string)
           capacity_min        = optional(string)
           capacity_max        = optional(string)
@@ -336,7 +336,7 @@ variable "network_security_group_rules" {
 
 variable "public_dns_zone_rg_name" {
   type        = string
-  description = "Name of the Resource Group containing the public DNS zones in the Hub subscription."
+  description = "Name of the Resource Group containing the public DNS zones in the Hub subscription, for App Service Custom Domains DNS challenges."
   default     = null
 }
 

--- a/infrastructure/tf-core/web_app.tf
+++ b/infrastructure/tf-core/web_app.tf
@@ -44,9 +44,8 @@ module "linux_web_app" {
   # storage_name               = var.linux_web_app.storage_name
   # storage_type               = var.linux_web_app.storage_type
   vnet_integration_subnet_id = module.subnets["${module.regions_config[each.value.region].names.subnet}-webapps"].id
-  # wildcard_ssl_cert_id       = each.value.custom_domains != null ? module.app-service-plan["${each.value.app_service_plan_key}-${each.value.region}"].wildcard_ssl_cert_id : null
-  wildcard_ssl_cert_id = each.value.custom_domains != null ? data.azurerm_app_service_certificate.wildcard.id : null
-  worker_32bit         = var.linux_web_app.worker_32bit
+  wildcard_ssl_cert_id       = each.value.custom_domains != null ? module.app-service-plan["${each.value.app_service_plan_key}-${each.value.region}"].wildcard_ssl_cert_id : null
+  worker_32bit               = var.linux_web_app.worker_32bit
 
   tags = merge(
     var.tags,
@@ -57,12 +56,6 @@ module "linux_web_app" {
       "hidden-link: /app-insights-conn-string"         = data.azurerm_application_insights.ai.connection_string
     }
   )
-}
-
-# Temporary workaround
-data "azurerm_app_service_certificate" "wildcard" {
-  name                = "wildcard-nonlive-nationalscreening"
-  resource_group_name = "rg-parman-dev-uks"
 }
 
 locals {


### PR DESCRIPTION
<!-- markdownlint-disable-next-line first-line-heading -->
## Description

This PR allows an App Service to be configured with the same public hostname and SSL certificate binding as the Application Gateway configuration, in line with recommended best practice for publishing the App Services with WAF protection (i.e. to avoid clunky and confusing header re-write rules).

It fully automates App Service certificate bindings, working around the issue of Azure not yet supporting Key Vault imports of certificates using elliptic curve cryptography (Azure Support Case 2505010050001340).

In the Hub I have had to export `.pfx` file blobs of certificates and store them as Key Vault Secret objects (in addition to the existing Certificate objects), and this project's Terraform uses that `.pfx` data instead. The downside of this workaround is that if an SSL certificate in the Hub Key Vault is renewed, then unfortunately the App Service will not automatically pick up that renewal unless this project Terraform is re-deployed. I think it's a fair assumption that these environments will be deployed more than once every 3 months (the lifespan of a LetsEncrypt SSL cert), so we do not expect this to be an issue.

Hopefully Microsoft will fix Azure App Service direct Key Vault Certificate references for elliptic curve certs, but this defect has persisted for many years so far. Most Public Certificate Authorities made elliptic curve the default cryptography for SSL certs in about 2019, so Microsoft is 6 years behind the times - not least because there is still no Azure Certificate Manager product.

Linked to:
- https://github.com/NHSDigital/dtos-devops-templates/pull/153
- https://github.com/NHSDigital/dtos-hub/pull/84

## Testing
- Successfully deployed to Dev: https://dev.azure.com/nhse-dtos/dtos-participant-manager/_build/results?buildId=18169&view=results
- Frontend website url is now: https://www-dev.non-live.screening.nhs.uk/


## Type of changes

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] Refactoring (non-breaking change)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would change existing functionality)
- [ ] Bug fix (non-breaking change which fixes an issue)

## Checklist

<!-- Go over all the following points, and put an `x` in all the boxes that apply. -->

- [x] I am familiar with the [contributing guidelines](../docs/CONTRIBUTING.md)
- [x] I have followed the code style of the project
- [ ] I have added tests to cover my changes
- [ ] I have updated the documentation accordingly
- [ ] This PR is a result of pair or mob programming

---

## Sensitive Information Declaration

To ensure the utmost confidentiality and protect your and others privacy, we kindly ask you to NOT including [PII (Personal Identifiable Information) / PID (Personal Identifiable Data)](https://digital.nhs.uk/data-and-information/keeping-data-safe-and-benefitting-the-public) or any other sensitive data in this PR (Pull Request) and the codebase changes. We will remove any PR that do contain any sensitive information. We really appreciate your cooperation in this matter.

- [x] I confirm that neither PII/PID nor sensitive data are included in this PR and the codebase changes.
